### PR TITLE
Check for absolute paths

### DIFF
--- a/lib/models/result-model.coffee
+++ b/lib/models/result-model.coffee
@@ -9,7 +9,8 @@ module.exports =
       @processResultString(response)
 
     getFilePath: ->
-      return path.join(@cwd, @fileName)
+      filePath = if @fileName.startsWith('/') then @fileName else path.join(@cwd, @fileName)
+      return filePath
     
     processResultString: (response) ->
       @resultString = response


### PR DESCRIPTION
I realized that absolute paths on results couldn't be opened. I think this fix that. Hope it helps.
