### PR TITLE
implement stack of locations

### DIFF
--- a/menus/atom-cscope.cson
+++ b/menus/atom-cscope.cson
@@ -52,6 +52,14 @@
           'label': 'Find assignments to variable under cursor/selection'
           'command': 'atom-cscope:find-assignments-to'
         }
+        {
+          'label': 'Go to the next location in the stack'
+          'command': 'atom-cscope:next'
+        },
+        {
+          'label': 'Go to the previous location in the stack'
+          'command': 'atom-cscope:prev'
+        }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
       "atom-cscope:toggle-files-including",
       "atom-cscope:toggle-assignments-to",
       "atom-cscope:refresh-db",
-      "atom-cscope:project-select"
+      "atom-cscope:project-select",
+      "atom-cscope:next",
+      "atom-cscope:prev"
     ]
   },
   "repository": "https://github.com/amitab/atom-cscope",


### PR DESCRIPTION
Keep a stack of locations were we jumped by the module.
Provide commands to jump back and forth.
I make keymaps for these two and 'find-global-definition' to
easily navigate through a big C language project
(linux kernel)

I never used JS of CoffeScript before so the code is probably of very low quality.  Still I need this feature.  Could you please consider merging it?

BTW, thank you for the very useful package.
