### PR TITLE
Implement stack of locations v2

### DIFF
--- a/lib/atom-cscope.coffee
+++ b/lib/atom-cscope.coffee
@@ -8,6 +8,10 @@ module.exports = AtomCscope =
   modalPanel: null
   subscriptions: null
 
+  historyPrev: []
+  historyCurr: null
+  historyNext: []
+
   config:
     LiveSearch:
       title: 'Live Search toggle'
@@ -76,8 +80,60 @@ module.exports = AtomCscope =
           notifier.addError "Error: " + data.message
         
     @atomCscopeView.onResultClick (result) =>
-      atom.workspace.open(result.getFilePath(), {initialLine: (result.lineNumber - 1)})
-  
+
+      if not @historyCurr?
+        @pushCurrentToHistoryPrev()
+      else
+        if @historyCurr.keyword?
+          if @historyCurr.keyword isnt result.keyword
+            @historyPrevPush @historyCurr
+            @pushCurrentToHistoryPrev()
+        else
+          @pushCurrentToHistoryPrev()
+
+      @historyCurr =
+        path: result.getFilePath()
+        pos:
+          column: 0
+          row: result.lineNumber - 1
+        keyword: result.keyword
+      @historyNext = []
+
+      @openHistoryCurr()
+
+  pushCurrentToHistoryPrev: ->
+    editor = atom.workspace.getActiveTextEditor()
+    pos = editor?.getCursorBufferPosition()
+    file = editor?.buffer.file
+    filePath = file?.path
+    if pos? and filePath?
+      @historyPrevPush
+        path: filePath
+        pos: pos
+        keyword: null
+
+  historyPrevPush: (item) ->
+    @historyPrev.push item
+    if @historyPrev.length > 30
+      @historyPrev.shift()
+
+  openHistoryCurr: ->
+    atom.workspace.open(@historyCurr.path, {initialLine: @historyCurr.pos.row, initialColumn: @historyCurr.pos.column})
+
+  goNext: ->
+    next = @historyNext.pop()
+    return if not next?
+    @historyPrev.push @historyCurr if @historyCurr?
+    @historyCurr = next
+    @openHistoryCurr()
+
+  goPrev: ->
+    prev = @historyPrev.pop()
+    return if not prev?
+    @historyNext.push @historyCurr if @historyCurr?
+    @historyCurr = prev
+    @openHistoryCurr()
+
   togglePanelOption: (option) ->
     if @atomCscopeView.inputView.getSelectedOption() is option
       @toggle()
@@ -94,6 +150,8 @@ module.exports = AtomCscope =
       'atom-cscope:focus-next': => @switchPanes() if @modalPanel.isVisible()
       'atom-cscope:refresh-db': => @refreshCscopeDB()
       'atom-cscope:project-select': => @atomCscopeView.inputView.openProjectSelector()
+      'atom-cscope:next': => @goNext()
+      'atom-cscope:prev': => @goPrev()
       
     @subscriptions.add atom.commands.add 'atom-workspace', 
       'atom-cscope:toggle-symbol': => @togglePanelOption(0)

--- a/menus/atom-cscope.cson
+++ b/menus/atom-cscope.cson
@@ -52,6 +52,14 @@
           'label': 'Find assignments to variable under cursor/selection'
           'command': 'atom-cscope:find-assignments-to'
         }
+        {
+          'label': 'Go to the next location in the stack'
+          'command': 'atom-cscope:next'
+        },
+        {
+          'label': 'Go to the previous location in the stack'
+          'command': 'atom-cscope:prev'
+        }
       ]
     ]
   }

--- a/menus/atom-cscope.cson
+++ b/menus/atom-cscope.cson
@@ -10,7 +10,7 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'atom-cscope'
+      'label': 'Cscope'
       'submenu': [
         {
           'label': 'Toggle Widget'

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
       "atom-cscope:toggle-files-including",
       "atom-cscope:toggle-assignments-to",
       "atom-cscope:refresh-db",
-      "atom-cscope:project-select"
+      "atom-cscope:project-select",
+      "atom-cscope:next",
+      "atom-cscope:prev"
     ]
   },
   "repository": "https://github.com/amitab/atom-cscope",


### PR DESCRIPTION
Keep a stack of locations were we jumped by the module.
Provide commands to jump back and forth.
I make keymaps for these two and 'find-global-definition' to
easily navigate through a big C language project
(linux kernel)

v2: restrict the length ot stack

This branch also contains a patch to fix the label in the 'Packages' menu.  This way the label follows the style of other labels