### PR TITLE
Add option to show cscope widget panel on the right

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -24,7 +24,7 @@ module.exports =
     description: 'Where do you want the widget?'
     type: 'string'
     default: 'top'
-    enum: ['top', 'bottom']
+    enum: ['top', 'bottom', 'right']
   cscopeSourceFiles:
     title: 'Source file extensions'
     description: 'Enter the extensions of the source files with which you want cscope generated (with spaces)'

--- a/lib/viewModels/atom-cscope-view-model.coffee
+++ b/lib/viewModels/atom-cscope-view-model.coffee
@@ -46,6 +46,7 @@ class AtomCscopeViewModel
     switch atom.config.get('atom-cscope.WidgetLocation')
       when 'bottom' then @modalPanel = atom.workspace.addBottomPanel(item: @view.getElement(), visible: false)
       when 'top' then @modalPanel = atom.workspace.addTopPanel(item: @view.getElement(), visible: false)
+      when 'right' then @modalPanel = atom.workspace.addRightPanel(item: @view.getElement(), visible: false)
       else @modalPanel = atom.workspace.addTopPanel(item: @view.getElement(), visible: false)
 
   setupEvents: () ->


### PR DESCRIPTION
This is useful for those who use Atom full screen on wide screen
monitors and have empty horizontal space.